### PR TITLE
Fix spread submission helper placement

### DIFF
--- a/options/orders.py
+++ b/options/orders.py
@@ -39,7 +39,7 @@ class OptionsTrader:
 
         return self.client.submit_order(req)
 
-def submit_spread_paired(self, legs: List[Dict[str, Any]], tif: str = "day"):
+    def submit_spread_paired(self, legs: List[Dict[str, Any]], tif: str = "day"):
         """
         Submit two single-leg limit orders back-to-back.
         If the second fails to submit, we cancel the first.


### PR DESCRIPTION
## Summary
- indent `submit_spread_paired` so it is defined inside `OptionsTrader`

## Testing
- `PYTHONPATH=. python scripts/test_options_smoke.py` *(fails: missing Alpaca API credentials in test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa1e44684832286d1be23e857d71d