### PR TITLE
Wire options strategy execution and exit monitoring

### DIFF
--- a/options/data.py
+++ b/options/data.py
@@ -30,6 +30,10 @@ class OptionsData:
         # Your callers expect a list of snapshots
         return list(resp.values())
 
+    # Backwards-compat alias (older code in the repo expected the pluralized name)
+    def chain_snapshots(self, underlying: str):
+        return self.chain_snapshot(underlying)
+
     def snapshots_for(self, symbols: list[str]):
         """
         Get snapshots for specific contract symbols (if you already picked contracts).


### PR DESCRIPTION
## Summary
- wire the options strategy lifecycle into the main scan so spread and CSP intents execute automatically
- persist option leg metadata and evaluate exit rules each tick to trigger take-profit/stop-loss closes
- add a backwards-compatible alias for fetching option chain snapshots

## Testing
- python -m compileall auto_trader.py options/data.py

------
https://chatgpt.com/codex/tasks/task_e_68dabfa50ca88322825e12a5c9168dd9