### PR TITLE
Use watchgod-based reloader for docker dev

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -2,7 +2,20 @@
 version: "3.9"
 services:
   auto_trader:
-    command: ["sh","-lc","python -m watchfiles --filter python --debounce 800 --ignore-paths /app/state --ignore-paths /app/logs --ignore-paths /app/.git --ignore-paths /app/__pycache__ --ignore-glob '*.log' 'python auto_trader.py' /app"]
+    command:
+      [
+        "python",
+        "scripts/run_with_reloader.py",
+        "--watch",
+        "/app",
+        "--ignore",
+        "/app/logs",
+        "--ignore",
+        "/app/state",
+        "--",
+        "python",
+        "auto_trader.py",
+      ]
     # Mount the whole repo into /app so edits in PyCharm appear in the container
     volumes:
       - ./:/app:delegated

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,20 @@
 version: '3.9'
 services:
   auto_trader:
-    command: ["sh","-lc","watchmedo auto-restart --patterns='*.py' --ignore-patterns='*.log;*/.git/*;*/__pycache__/*;*/logs/*;*/state/*' --recursive -- python auto_trader.py"]
+    command:
+      [
+        "python",
+        "scripts/run_with_reloader.py",
+        "--watch",
+        "/app",
+        "--ignore",
+        "/app/logs",
+        "--ignore",
+        "/app/state",
+        "--",
+        "python",
+        "auto_trader.py",
+      ]
     build: .
     image: wyatt/auto_trader:latest
     restart: unless-stopped

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ alpha-vantage
 pandas
 numpy
 PyYAML
-watchfiles
 requests
 python-dotenv
 ta


### PR DESCRIPTION
## Summary
- replace the docker development commands with a Python reloader script that watches project files without relying on watchfiles
- clean up the reloader helper to rely on watchgod, add absolute ignore handling, and document usage
- drop the unused watchfiles dependency from the requirements list

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68dd67e955d88322bfeef9c61f65c4c7