### PR TITLE
Cancel protective orders before exits to avoid insufficient qty errors

### DIFF
--- a/auto_trader.py
+++ b/auto_trader.py
@@ -241,6 +241,66 @@ def _int_from_env(name: str, default: int) -> int:
         logging.warning("Invalid int for env %s: %r -> using default %s", name, raw, default)
         return int(default)
 
+
+def _unwrap_pandas_scalar(value):
+    """Return a plain scalar from pandas objects without raising FutureWarning."""
+    if pd is None:
+        return value
+
+    if isinstance(value, pd.DataFrame):
+        if value.empty:
+            return None
+        # prefer the last column if multiple are present
+        try:
+            return _unwrap_pandas_scalar(value.iloc[-1])
+        except Exception:
+            return None
+
+    if isinstance(value, pd.Series):
+        if value.empty:
+            return None
+        try:
+            return _unwrap_pandas_scalar(value.iloc[-1])
+        except Exception:
+            return None
+
+    return value
+
+
+def _coerce_to_float(value):
+    """Best-effort conversion to float that tolerates pandas wrappers."""
+    value = _unwrap_pandas_scalar(value)
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _last_close_price(history):
+    """Extract the most recent close from a yfinance dataframe as a float."""
+    if history is None or getattr(history, "empty", True):
+        return None
+
+    try:
+        close = history["Close"]
+    except Exception:
+        return None
+
+    if pd is not None and isinstance(close, pd.DataFrame):
+        if close.empty:
+            return None
+        # take the last column for multi-index frames
+        close = close.iloc[:, -1]
+
+    try:
+        last_value = close.iloc[-1]
+    except Exception:
+        last_value = close
+
+    return _coerce_to_float(last_value)
+
 def _get_account_equity(api):
     """
     Return account equity (float). If API call fails, return None.
@@ -381,6 +441,14 @@ COUNT_OPTION_POSITIONS_TOWARD_MAX = (
 def _position_counts_toward_limit(position) -> bool:
     """Return True if the position should count toward the concurrency ceiling."""
     asset_class = str(getattr(position, "asset_class", "") or "").lower()
+    if not COUNT_OPTION_POSITIONS_TOWARD_MAX and asset_class in {"option", "us_option"}:
+        return False
+    return True
+
+
+def _order_counts_toward_limit(order) -> bool:
+    """Return True if an order should consume a concurrency slot when open."""
+    asset_class = str(getattr(order, "asset_class", "") or "").lower()
     if not COUNT_OPTION_POSITIONS_TOWARD_MAX and asset_class in {"option", "us_option"}:
         return False
     return True
@@ -604,7 +672,13 @@ def fetch_history_yf(ticker, lookback_days=60, interval="1d"):
         # yfinance can sometimes accept a list or a string; make sure we pass a string
         symbol = str(ticker).strip().upper()
         # request slightly more days to ensure we have SMA window
-        df = yf.download(symbol, period=f"{lookback_days}d", interval=interval, progress=False)
+        df = yf.download(
+            symbol,
+            period=f"{lookback_days}d",
+            interval=interval,
+            progress=False,
+            auto_adjust=False,
+        )
         if df is None or df.empty:
             return None
 
@@ -744,7 +818,13 @@ def compute_atr_stop_pct(ticker, atr_period=14, atr_multiplier=None):
         atr_multiplier = float(atr_multiplier or os.getenv("STOP_ATR_MULTIPLIER", "1.5"))
 
         symbol = str(ticker).strip().upper()
-        df = yf.download(symbol, period="60d", interval="1d", progress=False)
+        df = yf.download(
+            symbol,
+            period="60d",
+            interval="1d",
+            progress=False,
+            auto_adjust=False,
+        )
         if df is None or df.empty:
             logging.debug("compute_atr_stop_pct: no data for %s", symbol)
             return None
@@ -823,8 +903,14 @@ def place_market_buy_and_attach_stops(ticker, qty, entry_price_hint=None,
         price_for_sizing = float(entry_price_hint)
     else:
         try:
-            recent = yf.download(ticker, period="2d", interval="1d", progress=False)
-            price_for_sizing = float(recent["Close"].iloc[-1]) if recent is not None and not recent.empty else None
+            recent = yf.download(
+                ticker,
+                period="2d",
+                interval="1d",
+                progress=False,
+                auto_adjust=False,
+            )
+            price_for_sizing = _last_close_price(recent)
         except Exception:
             price_for_sizing = None
 
@@ -882,8 +968,14 @@ def place_market_buy_and_attach_stops(ticker, qty, entry_price_hint=None,
                 # Alpaca supports submitting a LIMIT order with order_class=bracket; for market+bracket, we use a limit slightly above market as fallback.
                 # We'll try submitting a MARKET buy without bracket first — many accounts require bracket on limit orders only.
                 # Recommended approach: submit limit bracket using a small slippage buffer from recent price.
-                recent = yf.download(ticker, period="2d", interval="1d", progress=False)
-                last_close = float(recent["Close"].iloc[-1]) if recent is not None and not recent.empty else entry_price_hint or None
+                recent = yf.download(
+                    ticker,
+                    period="2d",
+                    interval="1d",
+                    progress=False,
+                    auto_adjust=False,
+                )
+                last_close = _last_close_price(recent) or entry_price_hint or None
                 # compute a small limit, e.g., +0.5% above last close to approximate market but allow bracket
                 if last_close:
                     limit_price = round(last_close * 1.005, 2)
@@ -975,8 +1067,18 @@ def place_market_buy_and_attach_stops(ticker, qty, entry_price_hint=None,
 
         if not fill_price:
             logging.info("Proceeding without precise fill_price; using last close fallback.")
-            recent = yf.download(ticker, period="2d", interval="1d", progress=False)
-            fill_price = float(recent["Close"].iloc[-1]) if recent is not None and not recent.empty else entry_price_hint or fill_price or 0
+            recent = yf.download(
+                ticker,
+                period="2d",
+                interval="1d",
+                progress=False,
+                auto_adjust=False,
+            )
+            fallback_price = _last_close_price(recent)
+            if fallback_price is not None:
+                fill_price = fallback_price
+            else:
+                fill_price = entry_price_hint or fill_price or 0
 
         stop_price = round(fill_price * (1.0 - float(stop_pct)), 2)
         tp_price = round(fill_price * (1.0 + float(take_profit_pct)), 2)
@@ -1028,14 +1130,26 @@ def place_market_buy_and_attach_stops(ticker, qty, entry_price_hint=None,
             # fetch a recent price to decide whether to enable trailing immediately
             recent = None
             try:
-                recent = yf.download(ticker, period="1d", interval="1m", progress=False)
+                recent = yf.download(
+                    ticker,
+                    period="1d",
+                    interval="1m",
+                    progress=False,
+                    auto_adjust=False,
+                )
             except Exception:
                 # fallback to daily close if intraday fetch fails
-                recent = yf.download(ticker, period="2d", interval="1d", progress=False)
+                recent = yf.download(
+                    ticker,
+                    period="2d",
+                    interval="1d",
+                    progress=False,
+                    auto_adjust=False,
+                )
 
             current_price = None
             if recent is not None and not recent.empty:
-                current_price = float(recent["Close"].iloc[-1])
+                current_price = _last_close_price(recent)
             else:
                 current_price = fill_price or (limit_price if 'limit_price' in locals() else None) or 0.0
 
@@ -1638,7 +1752,9 @@ def run_scan_once():
         """
         Called each scan: for each state position with trail_active True,
         check whether we can raise the stop based on new high price.
+        Returns the number of stops successfully adjusted.
         """
+        adjustments = 0
         try:
             for ticker, pdata in list(state.get("positions", {}).items()):
                 if not pdata.get("trail_active"):
@@ -1650,7 +1766,13 @@ def run_scan_once():
 
                 # fetch recent minute bars to find the high since entry
                 try:
-                    df = yf.download(ticker, period="5d", interval="1m", progress=False)
+                    df = yf.download(
+                        ticker,
+                        period="5d",
+                        interval="1m",
+                        progress=False,
+                        auto_adjust=False,
+                    )
                     if df is None or df.empty:
                         continue
                     # only consider bars since entry_time if available
@@ -1687,10 +1809,12 @@ def run_scan_once():
                         save_state()
                         send_slack(
                             f":arrow_up: Raised stop for {ticker} to ${candidate_stop:.2f} (based on high ${high_since:.2f})")
+                        adjustments += 1
                     except Exception:
                         logging.exception("Failed to submit trailing stop for %s", ticker)
         except Exception:
             logging.exception("update_trailing_stops: general failure")
+        return adjustments
 
     # Run options lifecycle on each tick (exits before new entries)
     try:
@@ -1705,11 +1829,8 @@ def run_scan_once():
     # check account pause
     paused, drawdown = account_paused()
     if paused:
-        logging.error("Account paused due to drawdown %.2f%%", drawdown*100)
-        if paused:
-            logging.error("Account paused due to drawdown %.2f%%", drawdown * 100)
-            send_slack(f":warning: TRADING PAUSED — drawdown {drawdown:.2%}. Manual review required.")
-            return
+        logging.error("Account paused due to drawdown %.2f%%", drawdown * 100)
+        send_slack(f":warning: TRADING PAUSED — drawdown {drawdown:.2%}. Manual review required.")
         return
 
     acct = get_account_info()
@@ -1725,15 +1846,56 @@ def run_scan_once():
     open_positions = api.list_positions()
 
     counted_positions = [p for p in open_positions if _position_counts_toward_limit(p)]
-    open_symbols = set([p.symbol for p in counted_positions])
-    can_open_new_positions = len(counted_positions) < MAX_CONCURRENT_POSITIONS
+    counted_symbols = {p.symbol for p in counted_positions}
+    open_symbols = set(counted_symbols)
+
+    scan_started = time.monotonic()
+    symbols_considered = 0
+    buy_signals_seen = 0
+    sell_signals_seen = 0
+    buys_placed = 0
+    sells_placed = 0
+    concurrency_blocks = 0
+    pending_buy_skips = 0
+
+    pending_buy_symbols = set()
+    try:
+        open_orders = api.list_orders(status="open", limit=200, nested=True)
+    except Exception:
+        logging.exception(
+            "Failed to fetch open orders; pending-order safeguards temporarily disabled."
+        )
+        open_orders = []
+    else:
+        pending_buy_symbols = {
+            getattr(order, "symbol", "").upper()
+            for order in open_orders
+            if getattr(order, "symbol", None)
+            and str(getattr(order, "side", "")).lower() == "buy"
+            and _order_counts_toward_limit(order)
+        }
+
+    open_symbols.update(pending_buy_symbols)
+
+    pending_slots = sum(1 for sym in pending_buy_symbols if sym not in counted_symbols)
+    active_slots = len(counted_symbols) + pending_slots
+    can_open_new_positions = active_slots < MAX_CONCURRENT_POSITIONS
     if not can_open_new_positions:
         logging.info(
-            "Max concurrent positions reached (%d). Counting %d qualifying positions (total open positions: %d). Suppressing new entries but continuing exit checks.",
+            "Max concurrent positions reached (%d). Counting %d filled and %d pending-buy slots (total open positions: %d). Suppressing new entries but continuing exit checks.",
             MAX_CONCURRENT_POSITIONS,
-            len(counted_positions),
+            len(counted_symbols),
+            pending_slots,
             len(open_positions),
         )
+    logging.info(
+        "Beginning scan cycle for %d symbols — slots used %d/%d (filled=%d, pending=%d).",
+        len(WATCHLIST),
+        min(active_slots, MAX_CONCURRENT_POSITIONS),
+        MAX_CONCURRENT_POSITIONS,
+        len(counted_symbols),
+        pending_slots,
+    )
 
     def pick_top_n_signals(candidates, n=3):
         """
@@ -1748,6 +1910,7 @@ def run_scan_once():
     for ticker in WATCHLIST:
         try:
             ticker = ticker.strip().upper()
+            symbols_considered += 1
             # cooldown check
             last = state["last_signal"].get(ticker)
             if last:
@@ -1889,8 +2052,17 @@ def run_scan_once():
 
             # if buy signal and we don't already have a position in ticker -> consider entry
             if sig == "buy" and ticker not in open_symbols:
+                buy_signals_seen += 1
                 if not can_open_new_positions:
                     logging.debug("Skipping %s buy — concurrency ceiling reached", ticker)
+                    concurrency_blocks += 1
+                    continue
+                if ticker in pending_buy_symbols:
+                    logging.info(
+                        "Skipping %s buy — existing open BUY order still pending fill.",
+                        ticker,
+                    )
+                    pending_buy_skips += 1
                     continue
                 # sizing
                 qty = calc_shares_for_risk(equity, available_funds, MAX_RISK_PCT, price, STOP_PCT)
@@ -1909,6 +2081,8 @@ def run_scan_once():
                 status = getattr(order, "status", None) if order else "failed"
                 notes = ""
                 logging.info("Placed order for %s qty=%s id=%s status=%s", ticker, qty, order_id, status)
+                if order:
+                    buys_placed += 1
 
                 # ---- Slack alert for buy (safe) ----
                 try:
@@ -1929,6 +2103,13 @@ def run_scan_once():
                 except Exception:
                     notional = 0.0
                 available_funds = max(0.0, available_funds - notional)
+                if order:
+                    open_symbols.add(ticker)
+                    if ticker not in counted_symbols:
+                        pending_buy_symbols.add(ticker)
+                        pending_slots += 1
+                        active_slots = min(MAX_CONCURRENT_POSITIONS, len(counted_symbols) + pending_slots)
+                        can_open_new_positions = active_slots < MAX_CONCURRENT_POSITIONS
                 # -------------------------------------
 
                 # record state and log
@@ -1965,19 +2146,6 @@ def run_scan_once():
                     "strategy": strategy_name,
                     "score": float(score or 0.0)
                 })
-
-                log_trade_row({
-                    "timestamp": datetime.now(timezone.utc).isoformat(),
-                    "ticker": ticker,
-                    "action": "BUY",
-                    "signal_price": price,
-                    "qty": qty,
-                    "order_id": order_id,
-                    "status": status,
-                    "notes": notes,
-                    "equity": equity,
-                    "cash": acct["cash"]
-                })
                 # refresh positions and potentially throttle more entries
                 open_positions = api.list_positions()
                 counted_positions = [p for p in open_positions if _position_counts_toward_limit(p)]
@@ -1988,6 +2156,7 @@ def run_scan_once():
 
             # if sell/exit signal and we already have position -> exit (market sell)
             elif sig == "sell" and ticker in open_symbols:
+                sell_signals_seen += 1
                 # place market sell for quantity we hold
                 pos = next((p for p in counted_positions if p.symbol == ticker), None)
                 if pos is None:
@@ -1995,13 +2164,40 @@ def run_scan_once():
                 if not pos:
                     continue
                 qty = float(pos.qty)
+                if qty <= 0:
+                    logging.info(
+                        "Skipping exit for %s — position reports non-positive quantity (%s).",
+                        ticker,
+                        qty,
+                    )
+                    state["positions"].pop(ticker, None)
+                    save_state()
+                    open_symbols.discard(ticker)
+                    counted_symbols.discard(ticker)
+                    continue
+
+                pdata = state.get("positions", {}).get(ticker, {})
+                # Cancel any resting protective orders so the shares are available for exit.
+                for field, label in (("stop_order_id", "stop"), ("tp_order_id", "take-profit")):
+                    oid = pdata.get(field)
+                    if not oid:
+                        continue
+                    try:
+                        api.cancel_order(oid)
+                        logging.info("Cancelled %s order %s for %s prior to exit.", label, oid, ticker)
+                        pdata.pop(field, None)
+                        state["positions"][ticker] = pdata
+                        save_state()
+                    except Exception:
+                        logging.exception("Failed to cancel %s order %s for %s prior to exit.", label, oid, ticker)
+
                 try:
                     order = api.submit_order(symbol=ticker, qty=qty, side='sell', type='market', time_in_force='day')
                     order_id = getattr(order, "id", None)
                     status = getattr(order, "status", None)
                     notes = "exit signal"
                     logging.info("Placed exit for %s qty=%s id=%s", ticker, qty, order_id)
-                    logging.info("Placed exit for %s qty=%s id=%s", ticker, qty, order_id)
+                    sells_placed += 1
                     # Slack alert: exit placed
                     try:
                         send_slack(f":white_check_mark: EXIT {ticker} — qty={qty} @ ${price:.2f}  id={order_id}  status={status}")
@@ -2023,6 +2219,20 @@ def run_scan_once():
                         "equity": equity,
                         "cash": acct["cash"]
                     })
+                except APIError as e:
+                    message = str(e).lower()
+                    if "insufficient qty available" in message:
+                        logging.warning(
+                            "Exit order for %s skipped — Alpaca reports insufficient quantity available. Clearing local state.",
+                            ticker,
+                        )
+                        state["positions"].pop(ticker, None)
+                        save_state()
+                        open_symbols.discard(ticker)
+                        counted_symbols.discard(ticker)
+                        continue
+                    logging.exception("Failed to place exit order %s: %s", ticker, e)
+                    continue
                 except Exception as e:
                     logging.exception("Failed to place exit order %s: %s", ticker, e)
                     continue
@@ -2033,10 +2243,29 @@ def run_scan_once():
             continue
 
     # After processing every ticker, refresh any trailing-stop adjustments.
+    trailing_updates = 0
     try:
-        update_trailing_stops()
+        trailing_updates = update_trailing_stops()
     except Exception:
         logging.exception("update_trailing_stops failed at end of scan")
+
+    elapsed = time.monotonic() - scan_started
+    slots_used = min(active_slots, MAX_CONCURRENT_POSITIONS)
+    slots_remaining = max(0, MAX_CONCURRENT_POSITIONS - slots_used)
+    logging.info(
+        "Scan complete in %.1fs — considered %d symbols. Signals seen: buy=%d, sell=%d. Orders placed: buy=%d, sell=%d. Pending-buy skips=%d, concurrency blocks=%d, trailing updates=%d. Slots remaining: %d/%d.",
+        elapsed,
+        symbols_considered,
+        buy_signals_seen,
+        sell_signals_seen,
+        buys_placed,
+        sells_placed,
+        pending_buy_skips,
+        concurrency_blocks,
+        trailing_updates,
+        slots_remaining,
+        MAX_CONCURRENT_POSITIONS,
+    )
 
 def main_loop():
     logging.info("Starting auto_trader main loop. Watchlist: %s", WATCHLIST)
@@ -2049,6 +2278,7 @@ def main_loop():
         except Exception as e:
             logging.exception("Top-level error in main loop: %s", e)
             send_slack(f":bangbang: Top-level error in auto_trader: {e}")
+        logging.info("Sleeping for %d minutes before next scan.", SCAN_INTERVAL_MINUTES)
         time.sleep(SCAN_INTERVAL_MINUTES * 60)
 if __name__ == "__main__":
     main_loop()

--- a/scripts/run_with_reloader.py
+++ b/scripts/run_with_reloader.py
@@ -28,7 +28,9 @@ import time
 from pathlib import Path
 from typing import Iterable, Iterator, List, Sequence, Set, Tuple
 
-DEFAULT_IGNORES = {'.git', '__pycache__', '.pytest_cache', 'logs', 'state'}
+DEFAULT_IGNORES = {'.git', '__pycache__', '.pytest_cache', 'logs', 'state', 'auto_state.json'}
+DEFAULT_IGNORED_BASENAMES = {'auto_state.json', 'auto_trade_log.csv'}
+DEFAULT_IGNORED_PREFIXES = {'.auto_state.'}
 
 from watchgod.watcher import DefaultDirWatcher
 
@@ -137,7 +139,16 @@ class _DirWatcher(DefaultDirWatcher):
 
 
 def _is_ignored(path: Path, ignored: Set[Path]) -> bool:
-    return any(path == ignore or ignore in path.parents for ignore in ignored)
+    if any(path == ignore or ignore in path.parents for ignore in ignored):
+        return True
+
+    name = path.name
+    if name in DEFAULT_IGNORED_BASENAMES:
+        return True
+    if any(name.startswith(prefix) for prefix in DEFAULT_IGNORED_PREFIXES):
+        return True
+
+    return False
 
 
 def _watch_changes(


### PR DESCRIPTION
## Summary
- cancel resting stop and take-profit orders before submitting exit sells so Alpaca releases the reserved shares
- guard against non-positive position quantities and clear stale state when Alpaca reports no shares available

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd9731f67883228eecdc0623e113e6